### PR TITLE
Call parameter isn't increased resulting in no transfers

### DIFF
--- a/longpoll.go
+++ b/longpoll.go
@@ -376,7 +376,7 @@ func (t *longpollClientTransport) poll() {
 	close(t.messages)
 }
 
-func (t *longpollClientTransport) pollOnce(buf []byte) {
+func (t *longpollClientTransport) pollOnce() {
 	url := t.client.url(ClientModeLongPoll)
 	data := ClientMessage{
 		"__type":  PollMessage,


### PR DESCRIPTION
The `call` (client) or `seq` (server) parameter is never increased while executing longpolls. The result is that the transfer logic is never executed.

This can result in duplicate and missing messages imho.